### PR TITLE
Lower Elasticsearch dependency to 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.3
   - 7.4
   - nightly
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 7.3
   - 7.4
   - nightly
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     },
     "require": {
-        "php": "^7.3",
+        "php": "^7.4",
         "elasticsearch/elasticsearch": "^7.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
         }
     },
     "require": {
-        "php": "^7.4",
-        "elasticsearch/elasticsearch": "^7.9"
+        "php": "^7.3",
+        "elasticsearch/elasticsearch": "^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.4",


### PR DESCRIPTION
Lower dependencies to PHP 7.3 and Elasticsearch 7.0. Not going lower on the PHP version as 7.2 is unsupported in November 2020.