### PR TITLE
Support Elasticsearch 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     },
     "require": {
         "php": "^7.4||^8.0",
-        "elasticsearch/elasticsearch": "^7.11"
+        "elasticsearch/elasticsearch": "^7.11||^8.0@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.4",


### PR DESCRIPTION
Remove `@dev` once Elasticsearch releases a stable version.